### PR TITLE
Link to playground should point to playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## Playground
 Manually changing the config and generate the favicon to see the result might be time consuming. A faviator playground is created to allow us to tweak the config and view the result instantly.
 
-[Click here to go to the playground.](https://www.faviator.xyz/)
+[Click here to go to the playground.](https://www.faviator.xyz/playground)
 
 ## Install
 


### PR DESCRIPTION
It currently points to the landing page, which is a bit counter-intuitive.